### PR TITLE
ease scripts launch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,22 +22,16 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.6)
 SET(CXX_DISABLE_WERROR TRUE)
 INCLUDE(cmake/base.cmake)
 INCLUDE(cmake/python.cmake)
+INCLUDE(cmake/hpp.cmake)
 
 SET(PROJECT_NAME hpp_benchmark)
 SET(PROJECT_DESCRIPTION
   "Tutorial for humanoid path planner platform."
 )
-SET(PROJECT_URL "")
 
 FINDPYTHON()
 
-SETUP_PROJECT()
-
-# Activate hpp-util logging if requested
-SET (HPP_DEBUG FALSE CACHE BOOL "trigger hpp-util debug output")
-IF (HPP_DEBUG)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHPP_DEBUG")
-ENDIF()
+SETUP_HPP_PROJECT()
 
 ADD_DOC_DEPENDENCY("hpp-core >= 3")
 ADD_REQUIRED_DEPENDENCY("hpp-corbaserver >= 3")
@@ -57,11 +51,43 @@ install(FILES
   urdf/obstacle_easy.urdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/urdf
   )
-install(FILES srdf/lydia.srdf 
+install(FILES srdf/lydia.srdf
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/srdf
   )
 install (FILES
   src/hpp/corbaserver/lydia/robot.py
   src/hpp/corbaserver/lydia/__init__.py
   DESTINATION ${PYTHON_SITELIB}/hpp/corbaserver/lydia)
-SETUP_PROJECT_FINALIZE()
+
+install(FILES
+  future/baxter-manipulation-boxes/script.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/baxter-manipulation-boxes)
+
+install(FILES
+  future/construction-set/script.py
+  future/construction-set/setup.py
+  future/construction-set/state_name.py
+  future/construction-set/visibility_prm.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/construction-set)
+
+install(FILES
+  future/hrp2-on-the-ground/script.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/hrp2-on-the-ground)
+
+install(FILES
+  future/pr2-in-iai-kitchen/script.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/pr2-in-iai-kitchen)
+
+install(FILES
+  future/pr2-manipulation-kitchen/script.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/pr2-manipulation-kitchen)
+
+install(FILES
+  future/pr2-manipulation-two-hand/script.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/pr2-manipulation-two-hand)
+
+install(FILES
+  future/romeo-placard/script.py
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/romeo-placard)
+
+SETUP_HPP_PROJECT_FINALIZE()

--- a/future/baxter-manipulation-boxes/script.py
+++ b/future/baxter-manipulation-boxes/script.py
@@ -1,7 +1,11 @@
+#!/usr/bin/env python
 # Start hppcorbaserver before running this script
 # Note that an instance of omniNames should be running in background
 #
 # vim: foldmethod=marker foldlevel=2
+
+from argparse import ArgumentParser
+
 from hpp.corbaserver.manipulation.baxter import Robot
 from hpp.corbaserver.manipulation import ProblemSolver, ConstraintGraph, \
     ConstraintGraphFactory, Constraints, Rule, Client
@@ -11,6 +15,12 @@ from math import sqrt
 from hpp.corbaserver import loadServerPlugin
 loadServerPlugin ("corbaserver", "manipulation-corba.so")
 Client ().problem.resetProblem ()
+
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+parser.add_argument('--display', action='store_true')
+parser.add_argument('--run', action='store_true')
+args = parser.parse_args()
 
 # nbBoxes
 K = 2
@@ -174,8 +184,7 @@ ps.addGoalConfig (q_goal_proj)
 import datetime as dt
 totalTime = dt.timedelta (0)
 totalNumberNodes = 0
-N = 20
-for i in range (N):
+for i in range (args.N):
     ps.clearRoadmap ()
     ps.resetGoalConfigs ()
     ps.setInitialConfig (q_init_proj)
@@ -189,9 +198,12 @@ for i in range (N):
     totalNumberNodes += n
     print ("Number nodes: " + str(n))
 
-if N != 0:
-  print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (N)))
-  print ("Average number nodes: " + str (totalNumberNodes/float(N)))
+if args.N != 0:
+  print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (args.N)))
+  print ("Average number nodes: " + str (totalNumberNodes/float(args.N)))
 
-#v = vf.createViewer ()
-#pp = PathPlayer (v)
+if args.display:
+    v = vf.createViewer ()
+    pp = PathPlayer (v)
+    if args.run:
+        pp(0)

--- a/future/construction-set/script.py
+++ b/future/construction-set/script.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #
 #  Copyright (2017) CNRS
 #
@@ -8,6 +9,7 @@
 #
 
 import re, os
+from argparse import ArgumentParser
 from math import pi, fabs
 import hpp
 from hpp.corbaserver.manipulation import ConstraintGraphFactory, Rule
@@ -16,6 +18,12 @@ from hpp.gepetto import PathPlayer
 from state_name import StateName
 from visibility_prm import VisibilityPRM
 import time
+
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+parser.add_argument('--display', action='store_true')
+parser.add_argument('--run', action='store_true')
+args = parser.parse_args()
 
 def cleanPaths (ps, solutions) :
   offset = 0
@@ -110,8 +118,7 @@ def getEdges (graph, nodes, exploreNodes):
 dC = lambda q1,q2: reduce (lambda x,y : x if fabs (y [0]- y [1]) < x \
                            else fabs (y [0]- y [1]), zip (q1, q2), 0)
 
-display = False
-if display:
+if args.display:
   v = vf.createViewer ()
   pp = PathPlayer (v)
 else:
@@ -138,7 +145,7 @@ while i < nCylinder:
   i+=1; y = -y
 
 q0 = q0_r0 + q0_r1 + sum (q0_spheres, []) + sum (q0_cylinders, [])
-if display:
+if args.display:
   v (q0)
 
 # List of nodes composing the assembly sequence
@@ -303,8 +310,7 @@ solutions = list ()
 import datetime as dt
 totalTime = dt.timedelta (0)
 totalNumberNodes = 0
-N = 20
-for i in range (N):
+for i in range (args.N):
   numberNodes = 0
   # Try 20 times to solve the problem and stop at first success
   t1 = dt.datetime.now ()
@@ -331,7 +337,10 @@ for i in range (N):
   print ("Number nodes: " + str(n))
   totalNumberNodes += numberNodes
 
-if N != 0:
-  print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (N)))
-  print ("Average number nodes: " + str (totalNumberNodes/float(N)))
+if args.N != 0:
+  print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (args.N)))
+  print ("Average number nodes: " + str (totalNumberNodes/float(args.N)))
   cleanPaths (ps, solutions)
+
+if args.run:
+  pp(0)

--- a/future/hrp2-on-the-ground/script.py
+++ b/future/hrp2-on-the-ground/script.py
@@ -1,12 +1,20 @@
-#/usr/bin/env python
+#!/usr/bin/env python
 
 # Start hppcorbaserver before running this script
 # Note that an instance of omniNames should be running in background
 #
 
+from argparse import ArgumentParser
+
 from hpp.corbaserver.hrp2 import Robot
 from hpp.corbaserver import ProblemSolver
 from math import pi
+
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+parser.add_argument('--display', action='store_true')
+parser.add_argument('--run', action='store_true')
+args = parser.parse_args()
 
 Robot.urdfSuffix = '_capsule'
 Robot.srdfSuffix= '_capsule'
@@ -67,8 +75,7 @@ ps.selectPathValidation ("Progressive", 0.025)
 import datetime as dt
 totalTime = dt.timedelta (0)
 totalNumberNodes = 0
-N = 20
-for i in range (N):
+for i in range (args.N):
     ps.client.problem.clearRoadmap ()
     ps.resetGoalConfigs ()
     ps.setInitialConfig (q1proj)
@@ -82,11 +89,14 @@ for i in range (N):
     totalNumberNodes += n
     print ("Number nodes: " + str(n))
 
-print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (N)))
-print ("Average number nodes: " + str (totalNumberNodes/float (N)))
+print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (args.N)))
+print ("Average number nodes: " + str (totalNumberNodes/float (args.N)))
 
-from hpp.gepetto import ViewerFactory
-vf = ViewerFactory (ps)
-#v = vf.createViewer()
-from hpp.gepetto import PathPlayer
-#pp = PathPlayer (v, robot.client)
+if args.display:
+    from hpp.gepetto import ViewerFactory
+    vf = ViewerFactory (ps)
+    #v = vf.createViewer()
+    from hpp.gepetto import PathPlayer
+    pp = PathPlayer (v, robot.client)
+    if args.run:
+        pp(0)

--- a/future/pr2-in-iai-kitchen/script.py
+++ b/future/pr2-in-iai-kitchen/script.py
@@ -1,9 +1,18 @@
+#!/usr/bin/env python
 # Start hppcorbaserver before running this script
 # Note that an instance of omniNames should be running in background
 #
+
+from argparse import ArgumentParser
 from hpp.corbaserver.pr2 import Robot
 from hpp.gepetto import PathPlayer
 from math import pi
+
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+parser.add_argument('--display', action='store_true')
+parser.add_argument('--run', action='store_true')
+args = parser.parse_args()
 
 robot = Robot ('pr2')
 robot.setJointBounds ("root_joint", [-4, -3, -5, -3,-2,2,-2,2])
@@ -37,8 +46,7 @@ ps.selectPathValidation ("Progressive", 0.025)
 import datetime as dt
 totalTime = dt.timedelta (0)
 totalNumberNodes = 0
-N = 20
-for i in range (N):
+for i in range (args.N):
     ps.clearRoadmap ()
     ps.resetGoalConfigs ()
     ps.setInitialConfig (q_init)
@@ -52,9 +60,11 @@ for i in range (N):
     totalNumberNodes += n
     print ("Number nodes: " + str(n))
 
-print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (N)))
-print ("Average number nodes: " + str (totalNumberNodes/float (N)))
+print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (args.N)))
+print ("Average number nodes: " + str (totalNumberNodes/float (args.N)))
 
-#v = vf.createViewer(); v (q_init)
-#pp = PathPlayer (v, robot.client)
-
+if args.display:
+    v = vf.createViewer(); v (q_init)
+    pp = PathPlayer (v, robot.client)
+    if args.run:
+        pp(0)

--- a/future/pr2-manipulation-kitchen/script.py
+++ b/future/pr2-manipulation-kitchen/script.py
@@ -1,9 +1,11 @@
+#!/usr/bin/env python
 # Start hppcorbaserver before running this script
 # Note that an instance of omniNames should be running in background
 #
 # Import libraries and load robots. {{{1
 
 # Import. {{{2
+from argparse import ArgumentParser
 from math import sqrt
 from hpp.corbaserver.manipulation.pr2 import Robot
 from hpp.corbaserver.manipulation import ProblemSolver, ConstraintGraph, \
@@ -13,6 +15,14 @@ from math import pi
 from hpp.corbaserver import loadServerPlugin
 loadServerPlugin ("corbaserver", "manipulation-corba.so")
 Client ().problem.resetProblem ()
+# 2}}}
+
+# parse arguments {{{2
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+parser.add_argument('--display', action='store_true')
+parser.add_argument('--run', action='store_true')
+args = parser.parse_args()
 # 2}}}
 
 # Load PR2 and a box to be manipulated. {{{2
@@ -146,8 +156,8 @@ ps.setMaxIterPathPlanning (5000)
 import datetime as dt
 totalTime = dt.timedelta (0)
 totalNumberNodes = 0
-N = 20; success = 0
-for i in range (N):
+success = 0
+for i in range (args.N):
     ps.clearRoadmap ()
     ps.resetGoalConfigs ()
     ps.setInitialConfig (q_init)
@@ -172,8 +182,11 @@ print ("Average number nodes: " + str (totalNumberNodes/float (success)))
 
 # 1}}}
 
-from hpp.gepetto import PathPlayer
-#v = vf.createViewer (); v (q_init)
-#pp = PathPlayer (v, robot.client.basic)
+if args.display:
+    from hpp.gepetto import PathPlayer
+    v = vf.createViewer (); v (q_init)
+    pp = PathPlayer (v, robot.client.basic)
+    if args.run:
+        pp(0)
 
 # vim: foldmethod=marker foldlevel=1

--- a/future/pr2-manipulation-two-hand/script.py
+++ b/future/pr2-manipulation-two-hand/script.py
@@ -1,7 +1,9 @@
+#!/usr/bin/env python
 # Start hppcorbaserver before running this script
 # Note that an instance of omniNames should be running in background
 #
 # vim: foldmethod=marker foldlevel=2
+from argparse import ArgumentParser
 from hpp.corbaserver.manipulation.pr2 import Robot
 from hpp.corbaserver.manipulation import ProblemSolver, Constraints, \
   ConstraintGraph, ConstraintGraphFactory, Rule, Client
@@ -9,6 +11,13 @@ from hpp.gepetto.manipulation import Viewer, ViewerFactory
 from hpp.gepetto import PathPlayer
 from math import sqrt
 from hpp.corbaserver import loadServerPlugin
+
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+parser.add_argument('--display', action='store_true')
+parser.add_argument('--run', action='store_true')
+args = parser.parse_args()
+
 loadServerPlugin ("corbaserver", "manipulation-corba.so")
 Client ().problem.resetProblem ()
 
@@ -151,8 +160,7 @@ q_goal = res [1]
 import datetime as dt
 totalTime = dt.timedelta (0)
 totalNumberNodes = 0
-N = 20
-for i in range (N):
+for i in range (args.N):
     ps.clearRoadmap ()
     ps.resetGoalConfigs ()
     ps.setInitialConfig (q_init)
@@ -166,9 +174,11 @@ for i in range (N):
     totalNumberNodes += n
     print ("Number nodes: " + str(n))
 
-print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (N)))
-print ("Average number nodes: " + str (totalNumberNodes/float (N)))
+print ("Average time: " + str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (args.N)))
+print ("Average number nodes: " + str (totalNumberNodes/float (args.N)))
 
-#v = vf.createViewer ()
-#pp = PathPlayer (v, robot.client.basic)
-
+if args.display:
+    v = vf.createViewer ()
+    pp = PathPlayer (v, robot.client.basic)
+    if args.run:
+        pp(0)

--- a/future/romeo-placard/script.py
+++ b/future/romeo-placard/script.py
@@ -1,8 +1,10 @@
+#!/usr/bin/env python
 # Start hppcorbaserver before running this script
 # Note that an instance of omniNames should be running in background
 #
 
 from __future__ import print_function
+from argparse import ArgumentParser
 import time, CORBA, re, os, sys
 from hpp.corbaserver.manipulation import ProblemSolver, ConstraintGraph, \
     ConstraintGraphFactory, Constraints, Rule, Client
@@ -11,6 +13,13 @@ from hpp.gepetto.manipulation import Viewer, ViewerFactory
 from hpp.gepetto import PathPlayer
 from hpp import Transform
 from hpp.corbaserver import loadServerPlugin
+
+parser = ArgumentParser()
+parser.add_argument('-N', default=20, type=int)
+parser.add_argument('--display', action='store_true')
+parser.add_argument('--run', action='store_true')
+args = parser.parse_args()
+
 loadServerPlugin ("corbaserver", "manipulation-corba.so")
 Client ().problem.resetProblem ()
 
@@ -134,7 +143,7 @@ cg = ConstraintGraph.buildGenericGraph (robot, "graph",
 # factory.setObjects ([placard.name,], handlesPerObjects, [[],])
 # factory.setRules (rules)
 # factory.generate ()
-  
+
 cg.addConstraints (graph = True, constraints = commonConstraints)
 cg.initialize ()
 
@@ -154,8 +163,7 @@ ps.selectPathProjector ("Progressive", .05)
 import datetime as dt
 totalTime = dt.timedelta (0)
 totalNumberNodes = 0
-N = 20
-for i in range (N):
+for i in range (args.N):
     ps.clearRoadmap ()
     ps.resetGoalConfigs ()
     ps.setInitialConfig (q_init)
@@ -169,13 +177,17 @@ for i in range (N):
     totalNumberNodes += n
     print ("Number nodes: " + str(n))
 
-if N!=0:
+if args.N!=0:
   print ("Average time: " +
-         str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (N)))
-  print ("Average number nodes: " + str (totalNumberNodes/float (N)))
+         str ((totalTime.seconds+1e-6*totalTime.microseconds)/float (args.N)))
+  print ("Average number nodes: " + str (totalNumberNodes/float (args.N)))
 
-# v = vf.createViewer ()
-# v (q)
+if args.display:
+    v = vf.createViewer ()
+    v (q)
+    pp = PathPlayer(v)
+    if args.run:
+        pp(0)
 
 def toVector (s):
   return map (float, filter (lambda x: x != "", s.split (" ")))


### PR DESCRIPTION
Hi,

I would like to be able to easily run the benchmark scripts. For this, this PR:
- installs the scripts from the `future` directory ;
- make those scripts executable and provide them an argument parser.

Now, one can do `./script.py` to get the same result as before, or run `./script.py -N 1 --display --run` to solve the problem only once and run the result in gepetto viewer.